### PR TITLE
23 be less strict with dependencies in requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Security
 
+### Dependencies
+- (#23) updated depencies and set lower bound so installing is less strict
+
 
 ## (v0.2.9) (16/10/2023)
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-xmltodict==0.13.0
-requests==2.28.2
-lxml==4.9.2
-pyproj==3.4.1
+xmltodict>=0.13.0
+requests>=2.31.0
+lxml>=5.1.0
+pyproj>=3.6.1


### PR DESCRIPTION
Hi regbers,

Here's a small PR adding lower bounds to the dependencies. I'm not sure If we should add upperbounds too, but that would be more restrictive so I opted to leave it like this.

I also bumped the versions especially for the security patches of the request packages.

Can you review this PR? 

Maybe I will spend some time to to improve the CI scripts to check multiple python versions, I believe we should be able to link it to the pyproject.toml, but we have to pickup #6 first.